### PR TITLE
Implement Jellyfin integration and UI improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,25 @@
 # MovieClipper
+
+MovieClipper scans a movie library and generates a short HEVC clip for each
+movie.  It provides a small web UI and can be run either directly with Python
+or inside a Docker container.
+
+## Running locally
+
+```
+pip install -r requirements.txt
+python run.py
+```
+
+The UI will be available on `http://localhost:8000`.
+
+## Docker
+
+```
+docker build -t movieclipper .
+docker run -p 8000:8000 -v /path/to/config:/config -v /movies:/movies \
+    -e MOVIECLIPPER_CONFIG_DIR=/config movieclipper
+```
+
+`/config` is where the application stores its configuration file.  Mount your
+movie library inside the container so it can read the files.

--- a/app/config.py
+++ b/app/config.py
@@ -18,6 +18,7 @@ def load_config():
     data.setdefault("processed_movies", [])
     data.setdefault("jellyfin", {"url": "", "api_key": ""})
     data.setdefault("library_path", "./movies")
+    data.setdefault("last_jellyfin_scan", "1970-01-01T00:00:00")
     return data
 
 def save_config(data):

--- a/app/jellyfin.py
+++ b/app/jellyfin.py
@@ -1,3 +1,43 @@
-def test_jellyfin_connection(url: str, api_key: str) -> bool:
-    # Stub for now
-    return url.startswith("http") and len(api_key) > 5
+"""Helpers for interacting with Jellyfin."""
+
+import logging
+from datetime import datetime
+from typing import Tuple, Optional
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+
+def _headers(api_key: str) -> dict:
+    return {"X-Emby-Token": api_key}
+
+
+def test_jellyfin_connection(url: str, api_key: str) -> Tuple[bool, str]:
+    """Try to reach the Jellyfin server and return status and message."""
+    try:
+        resp = requests.get(f"{url}/System/Info/Public", headers=_headers(api_key), timeout=5)
+        if resp.status_code == 200:
+            return True, "Connection successful"
+        return False, f"Status code {resp.status_code}"
+    except Exception as exc:  # pragma: no cover - network failure
+        logger.error("Jellyfin connection failed: %s", exc)
+        return False, str(exc)
+
+
+def get_latest_item_time(url: str, api_key: str) -> Optional[datetime]:
+    """Return the creation time of the most recently added library item."""
+    try:
+        resp = requests.get(
+            f"{url}/Items/Latest",
+            params={"Limit": 1},
+            headers=_headers(api_key),
+            timeout=5,
+        )
+        if resp.status_code == 200 and resp.json():
+            item = resp.json()[0]
+            return datetime.fromisoformat(item["DateCreated"].rstrip("Z"))
+    except Exception as exc:  # pragma: no cover - network failure
+        logger.error("Failed to query Jellyfin latest item: %s", exc)
+    return None
+

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -5,12 +5,14 @@
 </head>
 <body>
     <h1>Movie Backlog Scanner</h1>
-    <form action="/save-jellyfin" method="post">
+    <form action="/save-jellyfin" method="post" id="config-form">
         Jellyfin URL: <input name="url" value="{{ config.jellyfin.url }}"><br>
         API Key: <input name="api_key" value="{{ config.jellyfin.api_key }}"><br>
         Library Path: <input name="library_path" value="{{ config.library_path }}"><br>
         <button type="submit">Save Jellyfin Server</button>
+        <button type="button" id="test-btn">Test Connection</button>
     </form>
+    <pre id="log">{{ connection_log }}</pre>
     <form action="/start-scan" method="post" style="margin-top:10px;">
         <button type="submit">Start Scan</button>
     </form>
@@ -19,6 +21,7 @@
     </form>
 
     <h2>Progress</h2>
+    <progress value="{{ progress.index }}" max="{{ progress.total }}"></progress>
     <div>Movie {{ progress.index }} / {{ progress.total }}: {{ progress.current }}</div>
 
     <h2>Last Movies Scanned</h2>
@@ -27,6 +30,14 @@
         <li>{{ movie }}</li>
     {% endfor %}
     </ul>
-    </form>
+    <script>
+    document.getElementById('test-btn').addEventListener('click', async () => {
+        const form = document.getElementById('config-form');
+        const data = new FormData(form);
+        const res = await fetch('/test-jellyfin', {method: 'POST', body: data});
+        const json = await res.json();
+        document.getElementById('log').textContent = json.message;
+    });
+    </script>
 </body>
 </html>

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 jinja2
 python-multipart
+requests


### PR DESCRIPTION
## Summary
- improve README with usage details
- track last scan time in config
- implement Jellyfin API helpers and real connection test
- update main app with connection logging and Jellyfin-aware scanning
- add progress bar and connection test button to the template
- require `requests`

## Testing
- `python -m app.self_check` *(fails: ffmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842fe87836c832b9385174fb79e924c