### PR TITLE
Add ffmpeg to container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,10 @@ WORKDIR /app
 ENV MOVIECLIPPER_CONFIG_DIR=/config
 
 COPY requirements.txt .
-RUN pip install -r requirements.txt
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ffmpeg \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install -r requirements.txt
 
 VOLUME ["/config"]
 


### PR DESCRIPTION
## Summary
- install ffmpeg in Docker image so the application has access to it

## Testing
- `pytest -q` *(no tests found)*
- `python -m app.self_check` *(expected failure without ffmpeg installed on host)*

------
https://chatgpt.com/codex/tasks/task_e_6842ffecb1a4832ba02932f5fb98879c