### PR TITLE
Add more logs to scanning process

### DIFF
--- a/app/jellyfin.py
+++ b/app/jellyfin.py
@@ -28,6 +28,7 @@ def test_jellyfin_connection(url: str, api_key: str) -> Tuple[bool, str]:
 def get_latest_item_time(url: str, api_key: str) -> Optional[datetime]:
     """Return the creation time of the most recently added library item."""
     try:
+        logger.debug("Querying Jellyfin for latest item")
         resp = requests.get(
             f"{url}/Items/Latest",
             params={"Limit": 1},
@@ -36,7 +37,9 @@ def get_latest_item_time(url: str, api_key: str) -> Optional[datetime]:
         )
         if resp.status_code == 200 and resp.json():
             item = resp.json()[0]
-            return datetime.fromisoformat(item["DateCreated"].rstrip("Z"))
+            created = datetime.fromisoformat(item["DateCreated"].rstrip("Z"))
+            logger.debug("Latest item time: %s", created)
+            return created
     except Exception as exc:  # pragma: no cover - network failure
         logger.error("Failed to query Jellyfin latest item: %s", exc)
     return None

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -25,6 +25,11 @@ def scan_movies(directory: str, stop_event=None) -> Iterator[Path]:
     """Scan directory for movies and generate backlog clips."""
     directory = Path(directory)
     movies = get_movies_to_process(directory)
+    logger.info("Scanning %s for movies", directory)
+    if not movies:
+        logger.info("No unprocessed movies found")
+    else:
+        logger.info("%d movies queued for processing", len(movies))
     config = load_config()
     processed = set(config.get("processed_movies", []))
 
@@ -37,7 +42,10 @@ def scan_movies(directory: str, stop_event=None) -> Iterator[Path]:
         backlog_dir = movie.parent / "backlog"
         out_path = backlog_dir / movie.name
         if not out_path.exists():
+            logger.info("Creating clip for %s", movie)
             create_clip(movie, out_path, duration)
+        else:
+            logger.info("Clip already exists for %s", movie)
         processed.add(str(movie))
         config["processed_movies"] = list(processed)
         save_config(config)

--- a/app/self_check.py
+++ b/app/self_check.py
@@ -11,11 +11,15 @@ def run_checks() -> bool:
     if not check_ffmpeg():
         logger.error("ffmpeg not found")
         ok = False
+    else:
+        logger.info("ffmpeg check passed")
     try:
         load_config()
     except Exception as exc:
         logger.error("Failed to load config: %s", exc)
         ok = False
+    else:
+        logger.info("Config loaded successfully")
     return ok
 
 


### PR DESCRIPTION
## Summary
- improve diagnostic logs during self-check
- log ffmpeg checks and failures
- log progress in scanning routines and ffmpeg clip creation
- log Jellyfin queries
- log thread start/end in the web API

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684304456cdc832b95c14da583b06b66