### PR TITLE
Add live progress updates during scans

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,10 @@ async def home(request: Request):
         },
     )
 
+@app.get("/progress")
+async def progress_status():
+    return {"progress": progress, "recent": recent}
+
 @app.post("/test-jellyfin")
 async def test_jellyfin(url: str = Form(...), api_key: str = Form(...)):
     global connection_log

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -52,20 +52,20 @@
     </div>
 
     <!-- Progress -->
-    <div class="bg-gray-800 p-6 rounded-xl">
-      <h2 class="text-xl font-semibold mb-2">Progress</h2>
-      <progress value="{{ progress.index }}" max="{{ progress.total }}" class="w-full h-4"></progress>
-      <div class="mt-2">Movie {{ progress.index }} / {{ progress.total }}: {{ progress.current }}</div>
-    </div>
+      <div class="bg-gray-800 p-6 rounded-xl">
+        <h2 class="text-xl font-semibold mb-2">Progress</h2>
+        <progress id="progress-bar" value="{{ progress.index }}" max="{{ progress.total }}" class="w-full h-4"></progress>
+        <div id="progress-text" class="mt-2">Movie {{ progress.index }} / {{ progress.total }}: {{ progress.current }}</div>
+      </div>
 
     <!-- Last Movies Scanned -->
     <div class="bg-gray-800 p-6 rounded-xl">
       <h2 class="text-xl font-semibold mb-2">Last Movies Scanned</h2>
-      <ul class="list-disc list-inside space-y-1">
-        {% for movie in recent %}
-          <li>{{ movie }}</li>
-        {% endfor %}
-      </ul>
+        <ul id="recent-list" class="list-disc list-inside space-y-1">
+          {% for movie in recent %}
+            <li>{{ movie }}</li>
+          {% endfor %}
+        </ul>
     </div>
   </div>
 
@@ -77,6 +77,27 @@
       const json = await res.json();
       document.getElementById('log').textContent = json.message;
     });
+  </script>
+  <script>
+    async function refreshProgress() {
+      const res = await fetch('/progress');
+      if (!res.ok) return;
+      const data = await res.json();
+      const bar = document.getElementById('progress-bar');
+      bar.max = data.progress.total;
+      bar.value = data.progress.index;
+      document.getElementById('progress-text').textContent =
+        `Movie ${data.progress.index} / ${data.progress.total}: ${data.progress.current}`;
+      const list = document.getElementById('recent-list');
+      list.innerHTML = '';
+      for (const movie of data.recent) {
+        const li = document.createElement('li');
+        li.textContent = movie;
+        list.appendChild(li);
+      }
+    }
+    refreshProgress();
+    setInterval(refreshProgress, 1000);
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add `/progress` API endpoint to return progress and recent movies
- update index template to poll `/progress` and update progress UI

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m app.self_check` *(fails: ffmpeg not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6843067930dc832b8a3459c71611c6cb