### PR TITLE
Add compose file for GHCR image

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,15 @@ docker run -p 8000:8000 -v /path/to/config:/config -v /movies:/movies \
 
 `/config` is where the application stores its configuration file.  Mount your
 movie library inside the container so it can read the files.
+
+## Pulling from GHCR
+
+A prebuilt container image is available from the GitHub Container Registry.
+To run it using Docker Compose:
+
+```bash
+docker compose up
+```
+
+The included `docker-compose.yml` pulls `ghcr.io/<user>/movieclipper:latest`
+and exposes the web UI on port 8000.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+services:
+  movieclipper:
+    image: ghcr.io/<user>/movieclipper:latest
+    ports:
+      - "8000:8000"
+    volumes:
+      - ./config:/config
+      - ./movies:/movies
+    environment:
+      - MOVIECLIPPER_CONFIG_DIR=/config


### PR DESCRIPTION
## Summary
- add docker-compose.yml referencing `ghcr.io/<user>/movieclipper:latest`
- document usage of GHCR image in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68430e84a604832b996c0ce2ab318ddb