### PR TITLE
Rename backlog to backdrops and fix scanning bug

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -115,13 +115,13 @@ async def stop_scan():
     return RedirectResponse("/", status_code=303)
 
 
-@app.post("/clear-backlogs")
-async def clear_backlogs():
+@app.post("/clear-backdrops")
+async def clear_backdrops():
     config = load_config()
     library = Path(config["library_path"])
-    for backlog in library.rglob("backlog"):
-        if backlog.is_dir():
-            shutil.rmtree(backlog)
+    for backdrop in library.rglob("backdrops"):
+        if backdrop.is_dir():
+            shutil.rmtree(backdrop)
     return RedirectResponse("/", status_code=303)
 
 @app.on_event("startup")

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -11,24 +11,26 @@ logger = logging.getLogger(__name__)
 def _find_movies(directory: Path) -> Iterator[Path]:
     exts = {".mkv", ".mp4", ".avi", ".mov"}
     for path in directory.rglob("*"):
+        if "backdrops" in path.parts:
+            continue
         if path.suffix.lower() in exts and path.is_file():
             yield path
 
 
 def get_movies_to_process(directory: Path) -> List[Path]:
-    """Return movies needing backlog clips."""
+    """Return movies needing backdrop clips."""
     config = load_config()
     processed = set(config.get("processed_movies", []))
     movies = []
     for p in _find_movies(directory):
-        backlog_path = p.parent / "backlog" / p.name
-        if not backlog_path.exists() or str(p) not in processed:
+        backdrop_path = p.parent / "backdrops" / p.name
+        if not backdrop_path.exists() or str(p) not in processed:
             movies.append(p)
     return movies
 
 
 def scan_movies(directory: str, stop_event=None, progress: dict | None = None) -> Iterator[Path]:
-    """Scan directory for movies and generate backlog clips."""
+    """Scan directory for movies and generate backdrop clips."""
     directory = Path(directory)
     movies = get_movies_to_process(directory)
     logger.info("Scanning %s for movies", directory)
@@ -47,8 +49,8 @@ def scan_movies(directory: str, stop_event=None, progress: dict | None = None) -
         if progress is not None:
             progress["movie_progress"] = 0
         duration = get_duration(movie)
-        backlog_dir = movie.parent / "backlog"
-        out_path = backlog_dir / movie.name
+        backdrop_dir = movie.parent / "backdrops"
+        out_path = backdrop_dir / movie.name
         if not out_path.exists():
             logger.info("Creating clip for %s", movie)
             create_clip(movie, out_path, duration, progress)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -2,13 +2,13 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8">
-  <title>Movie Backlog</title>
+  <title>Movie Backdrops</title>
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-gray-900 text-white min-h-screen p-6">
   <div class="max-w-3xl mx-auto space-y-8">
 
-    <h1 class="text-3xl font-bold text-center">Movie Backlog Scanner</h1>
+    <h1 class="text-3xl font-bold text-center">Movie Backdrop Scanner</h1>
 
     <!-- Config Form -->
     <form action="/save-jellyfin" method="post" id="config-form" class="bg-gray-800 p-6 rounded-xl shadow space-y-4">
@@ -49,9 +49,9 @@
           Stop Scan
         </button>
       </form>
-      <form action="/clear-backlogs" method="post">
+      <form action="/clear-backdrops" method="post">
         <button type="submit" class="bg-gray-600 hover:bg-gray-700 px-4 py-2 rounded font-semibold">
-          Clear Backlogs
+          Clear Backdrops
         </button>
       </form>
     </div>


### PR DESCRIPTION
## Summary
- rename backlog references to backdrops
- ignore backdrops folder while scanning so repeated scans do not nest directories

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m app.self_check` *(fails: ffmpeg not found)*

------
https://chatgpt.com/codex/tasks/task_e_68431b074ed0832bb80d22c1524b8698