### PR TITLE
Improve scan progress display and add options

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -19,6 +19,7 @@ def load_config():
     data.setdefault("jellyfin", {"url": "", "api_key": ""})
     data.setdefault("library_path", "/movies")
     data.setdefault("last_jellyfin_scan", "1970-01-01T00:00:00")
+    data.setdefault("clip_length", 10)
     return data
 
 def save_config(data):

--- a/app/ffmpeg_utils.py
+++ b/app/ffmpeg_utils.py
@@ -41,7 +41,13 @@ def get_duration(path: Path) -> float:
         return 0.0
 
 
-def create_clip(movie: Path, dest: Path, duration: float, progress: dict | None = None):
+def create_clip(
+    movie: Path,
+    dest: Path,
+    duration: float,
+    progress: dict | None = None,
+    clip_length: int = 10,
+):
     """Create a short clip for *movie* at *dest* updating *progress* if provided."""
     dest.parent.mkdir(parents=True, exist_ok=True)
     start = 0
@@ -58,7 +64,7 @@ def create_clip(movie: Path, dest: Path, duration: float, progress: dict | None 
         "-i",
         str(movie),
         "-t",
-        "10",
+        str(clip_length),
         "-c:v",
         "libx265",
         "-preset",
@@ -67,6 +73,8 @@ def create_clip(movie: Path, dest: Path, duration: float, progress: dict | None 
         "30",
         "-c:a",
         "aac",
+        "-af",
+        f"afade=t=in:st=0:d=1,afade=t=out:st={max(0, clip_length - 1)}:d=1",
         "-progress",
         "-",
         "-nostats",
@@ -80,7 +88,7 @@ def create_clip(movie: Path, dest: Path, duration: float, progress: dict | None 
         text=True,
         bufsize=1,
     )
-    total_ms = 10 * 1_000_000
+    total_ms = clip_length * 1_000_000
     if progress is not None:
         progress["movie_progress"] = 0
     while True:

--- a/app/main.py
+++ b/app/main.py
@@ -50,10 +50,16 @@ async def test_jellyfin(url: str = Form(...), api_key: str = Form(...)):
     return {"success": success, "message": message}
 
 @app.post("/save-jellyfin")
-async def save_jellyfin(url: str = Form(...), api_key: str = Form(...), library_path: str = Form(...)):
+async def save_jellyfin(
+    url: str = Form(...),
+    api_key: str = Form(...),
+    library_path: str = Form(...),
+    clip_length: int = Form(10),
+):
     config = load_config()
     config["jellyfin"] = {"url": url, "api_key": api_key}
     config["library_path"] = library_path
+    config["clip_length"] = clip_length
     save_config(config)
     return RedirectResponse("/", status_code=303)
 
@@ -84,9 +90,7 @@ async def start_scan():
 
     def _run():
         logger.info("Scan thread started")
-        for idx, movie in enumerate(scan_movies(config["library_path"], stop_event, progress), start=1):
-            progress["index"] = idx
-            progress["current"] = movie.name
+        for movie in scan_movies(config["library_path"], stop_event, progress):
             recent.insert(0, movie.name)
             del recent[5:]
         logger.info("Scan thread finished")

--- a/app/scanner.py
+++ b/app/scanner.py
@@ -41,19 +41,22 @@ def scan_movies(directory: str, stop_event=None, progress: dict | None = None) -
     config = load_config()
     processed = set(config.get("processed_movies", []))
 
-    for movie in movies:
+    for idx, movie in enumerate(movies, start=1):
         if stop_event and stop_event.is_set():
             logger.info("Scan stopped by user")
             break
         logger.info("Processing %s", movie)
         if progress is not None:
+            progress["index"] = idx
+            progress["current"] = movie.name
             progress["movie_progress"] = 0
         duration = get_duration(movie)
         backdrop_dir = movie.parent / "backdrops"
         out_path = backdrop_dir / movie.name
         if not out_path.exists():
             logger.info("Creating clip for %s", movie)
-            create_clip(movie, out_path, duration, progress)
+            clip_length = config.get("clip_length", 10)
+            create_clip(movie, out_path, duration, progress, clip_length=clip_length)
         else:
             logger.info("Clip already exists for %s", movie)
         processed.add(str(movie))

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -24,6 +24,10 @@
         <label class="block text-sm mb-1">Library Path</label>
         <input name="library_path" value="{{ config.library_path }}" class="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600" />
       </div>
+      <div>
+        <label class="block text-sm mb-1">Clip Length (seconds)</label>
+        <input name="clip_length" type="number" min="1" value="{{ config.clip_length }}" class="w-full px-3 py-2 rounded bg-gray-700 border border-gray-600" />
+      </div>
       <div class="flex gap-4 mt-4">
         <button type="submit" class="bg-blue-600 hover:bg-blue-700 px-4 py-2 rounded font-semibold">
           Save Jellyfin Server


### PR DESCRIPTION
## Summary
- display the movie currently being processed instead of the last one
- add configuration for backdrop clip length in the web UI
- apply audio fade-in/out to generated clips

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m app.self_check` *(fails: ffmpeg missing)*

------
https://chatgpt.com/codex/tasks/task_e_68446cadc9fc832bb4947bfdf8cce360